### PR TITLE
Keep WritableStream around for the lifetime of the object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gohai/p5.webserial",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A library for p5.js which adds support for interacting with Serial devices, using the Web Serial API (currently supported on Chrome and Edge)",
   "main": "libraries/p5.webserial",
   "directories": {


### PR DESCRIPTION
This fixes #8 (reported by @leoncity), where the second of two subsequent write()s without await fails because the stream is still locked, as the first write hasn't finished yet.