### PR TITLE
CH340 Redboard autodetect as possible Arduino

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,14 @@ function setup() {
   // ...
 ```
 
-To actually open a serial port, call the `open` method with the desired arguments. This prompts the user to select a serial port (at 9600 baud):
+To actually open a serial port, call the `open` method with the desired arguments. This shows a list of all serial ports and prompts the user which port to use (at 9600 baud):
 
 ```
 port.open(9600);
 ```
 
-This will only show Arduino boards (and compatible) in the dialog: (Other presets are `MicroPython`, `RaspberryPi`, `Adafruit`)
+To show only Arduino boards pass the `"Arduino"` argument. Other presets are `"MicroPython"`, `"RaspberryPi"`, and `"Adafruit"`. If your board is not auto-detected you can simply use the regular `open` call without a preset as above and have
+the user manually choose the port.
 
 ```
 port.open("Arduino", 9600);

--- a/libraries/p5.webserial.js
+++ b/libraries/p5.webserial.js
@@ -303,6 +303,7 @@
         { usbVendorId: 0x239a },                        // Adafruit
         { usbVendorId: 0x2a03 },                        // dog hunter AG
         { usbVendorId: 0x3343, usbProductId: 0x0043 },  // DFRobot UNO R3
+        { usbVendorId: 0x1A86, usbProductId: 0x7523 },  // CH340 serial converter, used on Sparkfun RedBoard and others
       ],
       'MicroPython': [                                  // from mu-editor as of 9/4/22
         { usbVendorId: 0x0403, usbProductId: 0x6001 },  // M5Stack & FT232/FT245 (XinaBox CW01, CW02)


### PR DESCRIPTION
I added the HL-340 / CH340 as a possible Arduino board for auto-detection and updated the README to clarify what to do if auto-detection fails.

Tested with the Sparkfun RedBoard, which uses the CH340 and is used in the kit for Intro to IM at NYUAD https://www.sparkfun.com/sparkfun-inventor-s-kit-v4-1-2.html

I believe the same chip is also used in other Arduino compatible boards.

Thanks for the great library, we've been having good success with it so far!

